### PR TITLE
Python guide

### DIFF
--- a/guides/style-guide-python.md
+++ b/guides/style-guide-python.md
@@ -1,0 +1,136 @@
+
+In general we try to follow the common community guidelines,
+including PEP-8 and PEP-257. But these don't cover everything
+important and we make a few exceptions.
+
+## flake8
+
+Every commit should pass an automated flake8 check with the plugins `pep8`,
+`mccabe`, and `pep8-naming` and this configuration:
+
+```ini
+# one section of flake.cfg
+
+[flake8]
+#ignore=E501,E225,E261,W391,E241,E203,W292,W391
+
+exclude=.git,migrations,docs,scripts
+max-complexity=8
+max-line-length = 119
+statistics=True
+jobs=1
+```
+
+### Commit hooks
+
+Git hooks are great for fast and light-weight tests. Here's how you can setup
+your commit hooks for automated style checks. This assumes your project has a
+Makefile with a linter command named `check`:
+
+    # .git/hooks/pre-commit
+
+    #!/bin/sh
+    make check
+
+Make sure that your virtualenv containing flake8 is activated when committing.
+Also note that this probably won't work form within Sourcetree, but it's better
+for you to stay in the shell anyway.
+
+*TODO: consider also using the `flake8-pep257` and `flake8-print` plugins to
+automate more tests.*
+
+## Documentation
+
+### class docstrings
+
+Whenever you create a class, add a docstring with at least a one-liner:
+
+```py
+class SomeClass(object):
+    """The one-line explaination"""
+    pass
+```
+
+If a longer description would be helpful, skip a line and use more sections
+(each is optional).  Don't provide useless information like "the attribute
+`name` is the name of the object":
+
+```py
+class SomeClass(object):
+    """Always start with a stand-alone one-liner
+
+    This class has no side-effects.
+
+    Attributes:
+        name: what end-users call this instance
+    """
+    pass
+```
+
+### Function docstrings
+
+Similarly:
+
+```py
+def simple_function(abc):
+    """This function ignores the arguments and always returns None"""
+    pass
+
+def complex_function(abc):
+    """Always use a one-liner
+
+    Arguments:
+        abc: the letters of the alphabet
+    """
+    pass
+```
+
+### Blank lines
+
+Don't include unnecessary blank lines around the docstrings.
+
+## Imports
+
+Do not use wildcard imports.
+
+Imports don't have to be in alphabetical order. It is however more or less of a
+convention that imports that are the furthest away from the current module in
+are the highest on top. So standard library imports like `os`, `system` etc. go
+on top. Then come imports from installed packages; `django`, `celery` etc. and
+finally that belong to the current project.
+
+Prefer one line for one import
+
+## Libraries
+
+Before adding a new library, consider the long-term maintenance cost and risk
+of abandoned projects. It's often easier to copy code into our project or write
+it ourselves. If we can't use a stable and recent PyPi release, the threshold
+for time-saved should be even higher.
+
+We have agreed that the following Python libraries are definitely worth it:
+
+- Django
+- Django REST Framework
+- Flask
+- Swagger / OpenAPI
+- psycopg2
+- elasticsearch
+- elasticsearch-dsl
+
+## Naming
+
+- don't start method names with `get_` or `set_`. Use properties if possible.
+
+## Testing
+
+- new behaviors should be accompanied by new tests
+- if a behavior is changed and no tests break, that indicates
+  an important hole in our coverage.
+- tests should work without internet access or a local database installed
+
+Use the following testing libraries:
+
+- Mock
+- py.test
+

--- a/guides/style-guide-python.md
+++ b/guides/style-guide-python.md
@@ -121,13 +121,9 @@ We prefer one line for one import.
 
 ## Testing
 
-- new behaviors should be accompanied by new tests
-- if a behavior is changed and no tests break, that indicates
-  an important hole in our coverage.
-- tests should work without internet access or a local database installed
+All new behaviors should be accompanied by new tests. If a behavior is changed and no tests break, that indicates an important hole in our coverage. Tests should work without internet access or a local database installed
 
-Use the following testing libraries:
+We usually use Mock and py.test.
 
-- Mock
-- py.test
+
 

--- a/guides/style-guide-python.md
+++ b/guides/style-guide-python.md
@@ -62,23 +62,8 @@ First of all, do not use wildcard imports.
 
 Imports don't have to be in alphabetical order. It is however more or less of a convention that imports that are the furthest away from the current module in are the highest on top. 
 
-## Libraries
 Standard library imports like `os`, `system` etc. go on top. Then come imports from installed packages; `django`, `celery` etc. and finally that belong to the current project.
 
-Before adding a new library, consider the long-term maintenance cost and risk
-of abandoned projects. It's often easier to copy code into our project or write
-it ourselves. If we can't use a stable and recent PyPi release, the threshold
-for time-saved should be even higher.
-
-We have agreed that the following Python libraries are definitely worth it:
-
-- Django
-- Django REST Framework
-- Flask
-- Swagger / OpenAPI
-- psycopg2
-- elasticsearch
-- elasticsearch-dsl
 We prefer one line for one import.
 
 ## Naming

--- a/guides/style-guide-python.md
+++ b/guides/style-guide-python.md
@@ -1,7 +1,4 @@
 
-In general we try to follow the common community guidelines,
-including PEP-8 and PEP-257. But these don't cover everything
-important and we make a few exceptions.
 
 ## flake8
 
@@ -26,8 +23,10 @@ jobs=1
 Git hooks are great for fast and light-weight tests. Here's how you can setup
 your commit hooks for automated style checks. This assumes your project has a
 Makefile with a linter command named `check`:
+# How we code Python
 
     # .git/hooks/pre-commit
+A lot of the software we make at City of Amsterdam is written in Python.
 
     #!/bin/sh
     make check
@@ -38,6 +37,10 @@ for you to stay in the shell anyway.
 
 *TODO: consider also using the `flake8-pep257` and `flake8-print` plugins to
 automate more tests.*
+In general we try to follow the common community guidelines,
+including [PEP-8: Style Guide for Python Code](https://www.python.org/dev/peps/pep-0008/) 
+and [PEP-257: Docstring Conventions](https://www.python.org/dev/peps/pep-0257/). But these 
+don't cover everything important to us, and in addition to that we have a few exceptions.
 
 ## Documentation
 

--- a/guides/style-guide-python.md
+++ b/guides/style-guide-python.md
@@ -42,7 +42,7 @@ including [PEP-8: Style Guide for Python Code](https://www.python.org/dev/peps/p
 and [PEP-257: Docstring Conventions](https://www.python.org/dev/peps/pep-0257/). But these 
 don't cover everything important to us, and in addition to that we have a few exceptions.
 
-## Documentation
+## Documenting your code
 
 ### class docstrings
 
@@ -87,8 +87,6 @@ def complex_function(abc):
     """
     pass
 ```
-
-### Blank lines
 
 Don't include unnecessary blank lines around the docstrings.
 

--- a/guides/style-guide-python.md
+++ b/guides/style-guide-python.md
@@ -1,3 +1,6 @@
+---
+explains: The style guide to the way we code Python
+---
 
 # How we code Python
 

--- a/guides/style-guide-python.md
+++ b/guides/style-guide-python.md
@@ -1,39 +1,8 @@
 
-
-## flake8
-
-Every commit should pass an automated flake8 check with the plugins `pep8`,
-`mccabe`, and `pep8-naming` and this configuration:
-
-```ini
-# one section of flake.cfg
-
-[flake8]
-#ignore=E501,E225,E261,W391,E241,E203,W292,W391
-
-exclude=.git,migrations,docs,scripts
-max-complexity=8
-max-line-length = 119
-statistics=True
-jobs=1
-```
-
-### Commit hooks
-
-Git hooks are great for fast and light-weight tests. Here's how you can setup
-your commit hooks for automated style checks. This assumes your project has a
-Makefile with a linter command named `check`:
 # How we code Python
 
-    # .git/hooks/pre-commit
 A lot of the software we make at City of Amsterdam is written in Python.
 
-    #!/bin/sh
-    make check
-
-Make sure that your virtualenv containing flake8 is activated when committing.
-Also note that this probably won't work form within Sourcetree, but it's better
-for you to stay in the shell anyway.
 
 *TODO: consider also using the `flake8-pep257` and `flake8-print` plugins to
 automate more tests.*
@@ -125,5 +94,32 @@ All new behaviors should be accompanied by new tests. If a behavior is changed a
 
 We usually use Mock and py.test.
 
+## Using `flake8` for style guide enforcement
 
+We use `flake8` in order to enforce a uniform code style. Every commit should pass an automated flake8 check with the plugins `pep8`, `mccabe`, and `pep8-naming` and this configuration:
 
+```ini
+# one section of flake.cfg
+
+[flake8]
+#ignore=E501,E225,E261,W391,E241,E203,W292,W391
+
+exclude=.git,migrations,docs,scripts
+max-complexity=8
+max-line-length = 119
+statistics=True
+jobs=1
+```
+
+### Commit hooks
+
+Git hooks are great for fast and light-weight tests. Here's how you can setup
+your commit hooks for automated style checks. This assumes your project has a
+Makefile with a linter command named `check`:
+
+    # .git/hooks/pre-commit
+
+    #!/bin/sh
+    make check
+
+Make sure that your virtualenv containing flake8 is activated when committing.

--- a/guides/style-guide-python.md
+++ b/guides/style-guide-python.md
@@ -92,17 +92,12 @@ Don't include unnecessary blank lines around the docstrings.
 
 ## Imports
 
-Do not use wildcard imports.
+First of all, do not use wildcard imports.
 
-Imports don't have to be in alphabetical order. It is however more or less of a
-convention that imports that are the furthest away from the current module in
-are the highest on top. So standard library imports like `os`, `system` etc. go
-on top. Then come imports from installed packages; `django`, `celery` etc. and
-finally that belong to the current project.
-
-Prefer one line for one import
+Imports don't have to be in alphabetical order. It is however more or less of a convention that imports that are the furthest away from the current module in are the highest on top. 
 
 ## Libraries
+Standard library imports like `os`, `system` etc. go on top. Then come imports from installed packages; `django`, `celery` etc. and finally that belong to the current project.
 
 Before adding a new library, consider the long-term maintenance cost and risk
 of abandoned projects. It's often easier to copy code into our project or write
@@ -118,6 +113,7 @@ We have agreed that the following Python libraries are definitely worth it:
 - psycopg2
 - elasticsearch
 - elasticsearch-dsl
+We prefer one line for one import.
 
 ## Naming
 

--- a/guides/style-guide-python.md
+++ b/guides/style-guide-python.md
@@ -3,9 +3,6 @@
 
 A lot of the software we make at City of Amsterdam is written in Python.
 
-
-*TODO: consider also using the `flake8-pep257` and `flake8-print` plugins to
-automate more tests.*
 In general we try to follow the common community guidelines,
 including [PEP-8: Style Guide for Python Code](https://www.python.org/dev/peps/pep-0008/) 
 and [PEP-257: Docstring Conventions](https://www.python.org/dev/peps/pep-0257/). But these 


### PR DESCRIPTION
A slightly restructured version of the [`contrib-guide` Python guide](https://github.com/Amsterdam/contrib-guide/blob/master/docs/python.md)

The only bit I've removed is the following, since I think it should have a home somewhere else as it is not about style:

> ## Libraries
>
> Before adding a new library, consider the long-term maintenance cost and risk of abandoned projects. It's often easier to copy code into our project or write it ourselves. If we can't use a stable and recent PyPi release, the threshold for time-saved should be even higher.
>
> We have agreed that the following Python libraries are definitely worth it:
>
> - Django
> - Django REST Framework
> - Flask
> - Swagger / OpenAPI
> - psycopg2
> - elasticsearch
> - elasticsearch-dsl

In this PR I'm also explicitly interested in what is missing from this guide

Closes #14 